### PR TITLE
Fix logical operator causing build failure

### DIFF
--- a/src/app/page.js
+++ b/src/app/page.js
@@ -103,7 +103,7 @@ export default function Home() {
             </select>
             <input className="border p-2 rounded" placeholder="Name" required value={form.name} onChange={e=>setForm({...form, name:e.target.value})} />
             <input className="border p-2 rounded" type="email" placeholder="Email" required value={form.email} onChange={e=>setForm({...form, email:e.target.value})} />
-            {(formType==='updates' || formType==='volunteer') and (""=="" ) and (
+            {(formType==='updates' || formType==='volunteer') && (
               <input className="border p-2 rounded" placeholder="Mobile (optional)" value={form.phone} onChange={e=>setForm({...form, phone:e.target.value})} />
             )}
             {(formType==='endorsement' || formType==='host' || formType==='meeting') && (


### PR DESCRIPTION
## Summary
- use JavaScript logical `&&` in `Home` form to gate optional phone field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689571788e3c8321a626aceb4c2a2e9a